### PR TITLE
bump version for lib to be php 8 compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">=5.3.0",
         "yiisoft/yii2": "*",
-        "giggsey/libphonenumber-for-php": "~7.0"
+        "giggsey/libphonenumber-for-php": "~8.0"
     },
     "autoload": {
         "psr-0" : {


### PR DESCRIPTION
serializable is deprecated, update the libphonenumber to 8